### PR TITLE
Better init file generation

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,5 +8,6 @@ license        'perl';
 # Specific dependencies
 requires       'File::Spec'     => '0';
 requires       'POSIX'          => '0';
+requires        'Cwd'           => '0';
 
 WriteAll;

--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use POSIX qw(_exit setsid setuid setgid getuid getgid);
 use File::Spec;
+use Cwd 'abs_path';
 require 5.008001; # Supporting 5.8.1+
 
 our $VERSION = '0.000009'; # 0.0.9
@@ -379,7 +380,7 @@ sub dump_init_script {
             REQUIRED_STOP     => $self->lsb_stop  ? $self->lsb_stop  : "",
             SHORT_DESCRIPTION => $self->lsb_sdesc ? $self->lsb_sdesc : "",
             DESCRIPTION       => $self->lsb_desc  ? $self->lsb_desc  : "",
-            SCRIPT            => $self->path      ? $self->path      : $0,
+            SCRIPT            => $self->path      ? $self->path      : abs_path($0),
             INIT_SOURCE_FILE  => $init_source_file,
         }
     ));
@@ -576,8 +577,7 @@ If provided, chdir to this directory before execution.
 
 The path of the script you are using Daemon::Control in.  This will be used in 
 the LSB file genration to point it to the location of the script.  If this is
-not provided $0 will be used, which is likely to work only if you use the full
-path to execute it when asking for the init script.
+not provided, the absolute path of $0 will be used.
 
 =head2 init_config
 


### PR DESCRIPTION
- documents a good value for init_config_file to use in a perlbrew environment
- if $0 is a relative path, we can figure out its absolute path, so that would make a nicer default than just $0.

Cwd is in core, so no additional dependencies are added.
