### PR TITLE
Fixed warning "Use of uninitialized value $called_with in substitution (s///) at Daemon-Control/lib/Daemon/Control.pm line 505."

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+    * fixed a warning on "uninitialized value $called_with in substitution"
+      (Kromg)
+
     * include the date and module version in the generated init file
       (Karen Etheridge)
 

--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -501,8 +501,11 @@ sub run {
         $self->trace( "Implicit GID => $gid" );
     }
 
-    my $called_with = shift @ARGV if @ARGV;
-    $called_with =~ s/^[-]+//g; # Allow people to do --command too.
+    my $called_with;
+    if (@ARGV) {
+        $called_with = shift @ARGV;
+        $called_with =~ s/^[-]+//g; # Allow people to do --command too.
+    }
 
     my $action = "do_" . ($called_with ? $called_with : "" );
 


### PR DESCRIPTION
Hi, 
  I got the warning above, and put the substitution under the same "if" that controls variable initialization. It should fix the problem. 
