### PR TITLE
Inlineable

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+    * fixed a warning on "uninitialized value $called_with in substitution"
+      (Kromg)
+
     * include the date and module version in the generated init file
       (Karen Etheridge)
 

--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -501,8 +501,11 @@ sub run {
         $self->trace( "Implicit GID => $gid" );
     }
 
-    my $called_with = shift @ARGV if @ARGV;
-    $called_with =~ s/^[-]+//g; # Allow people to do --command too.
+    my $called_with;
+    if (@ARGV) {
+        $called_with = shift @ARGV;
+        $called_with =~ s/^[-]+//g; # Allow people to do --command too.
+    }
 
     my $action = "do_" . ($called_with ? $called_with : "" );
 


### PR DESCRIPTION
Hi, 
  I have been asked (https://rt.cpan.org/Ticket/Display.html?id=82864) to merge my module Script::Daemonizer with yours, if possible, so I tried to get the same behaviour of my daemonize() method from run(). 
I moved the exit() to the methods that need it, and also let methods like do_status exit with 1 if process is not running, 0 if it is (this should be standard, AFAIK). If "program =>" is not defined, run() simply calls _fork() or _double_fork() and then returns, instead of exit()-ing (in the parent it prints "Started" and exits, of course). 

Please let me know if you're interested in this patch. I was also thinking about having an import tag like :DEFAULTS that could auto-initialize some quantities and behaviours (like, chdir to '/', use $0 as the default name, set umask to 0 and so on). I may implement this.

Thanks.