### PR TITLE
check every second for kill_timeout seconds if the daemon has terminated...

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 
     * create dir for pid_file if it does not exist
     * fix uninitialized warning in error when exec fails
+    * 'stop' is now faster when kill_timeout is set to high values, by checking
+      every second if the daemon has terminated rather than waiting for the
+      full kill_timeout duration
 
 0.001000  2013-02-26  SymKat <symkat@symkat.com>
     * fixed a warning on "uninitialized value $called_with in substitution"

--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -382,8 +382,16 @@ sub do_stop {
 
     if ( $self->pid && $self->pid_running ) {
         foreach my $signal ( qw(TERM TERM INT KILL) ) {
+            $self->trace( "Sending $signal signal to pid ", $self->pid, "..." );
             kill $signal => $self->pid;
-            sleep $self->kill_timeout;
+
+            for (1..$self->kill_timeout)
+            {
+                # abort early if the process is now stopped
+                $self->trace('checking if pid ', $self->pid, ' is still running...');
+                last if not $self->pid_running;
+                sleep 1;
+            }
             last unless $self->pid_running;
         }
         if ( $self->pid_running ) {


### PR DESCRIPTION
..., rather than only checking at the end
