### PR TITLE
"check_duplicate_process" feature

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@
     * 'stop' is now faster when kill_timeout is set to high values, by checking
       every second if the daemon has terminated rather than waiting for the
       full kill_timeout duration
+    * new option: prereq_no_process
 
 0.001000  2013-02-26  SymKat <symkat@symkat.com>
     * fixed a warning on "uninitialized value $called_with in substitution"


### PR DESCRIPTION
FEEDBACK REQUESTED
This is a little gross, but it should be safe to include as everything defaults to being turned off...  The problem I ran into was that the pid file vanished (not sure why) but the daemon was still running.. and then an IT guy came along and started it up, giving me a duplicate process, which caused a lot of mayhem. It would have been much better if the new process would have gone "hey! there's one already running.. I won't start!"

---

Searches the `ps` list for anything that looks like the daemon that might
already be running.

Both the program name and arguments are checked, as it appears different
operating systems vary as to how they populate `ps`:  On ubuntu, my daemon
looks like:

```
/path/to/perl /path/to/program args
```

but on CentOS, the very same code shows up as:

```
/path/to/program args
```
