### PR TITLE
Change the shebang from /usr/bin/perl to unbreak builds under custom perls

### DIFF
--- a/t/01_lsb_file.t
+++ b/t/01_lsb_file.t
@@ -17,7 +17,7 @@ if ( -f 't/bin/01_lsb.pl' ) { # Dist Directory.
 }
 
 
-open my $lf, "-|", "perl", "-I$ilib", $file, "get_init_file"
+open my $lf, "-|", $^X, "-I$ilib", $file, "get_init_file"
     or die "Failed to open pipe to $file: $!";
 my $content = do { local $/; <$lf> };
 close $lf;

--- a/t/01_lsb_file_with_init_code.t
+++ b/t/01_lsb_file_with_init_code.t
@@ -17,7 +17,7 @@ if ( -f 't/bin/01_lsb_03.pl' ) { # Dist Directory.
 }
 
 
-open my $lf, "-|", "perl", "-I$ilib", $file, "get_init_file"
+open my $lf, "-|", $^X, "-I$ilib", $file, "get_init_file"
     or die "Failed to open pipe to $file: $!";
 my $content = do { local $/; <$lf> };
 close $lf;

--- a/t/01_lsb_file_with_init_config.t
+++ b/t/01_lsb_file_with_init_config.t
@@ -17,7 +17,7 @@ if ( -f 't/bin/01_lsb_02.pl' ) { # Dist Directory.
 }
 
 
-open my $lf, "-|", "perl", "-I$ilib", $file, "get_init_file"
+open my $lf, "-|", $^X, "-I$ilib", $file, "get_init_file"
     or die "Failed to open pipe to $file: $!";
 my $content = do { local $/; <$lf> };
 close $lf;

--- a/t/02_sleep_perl.t
+++ b/t/02_sleep_perl.t
@@ -28,26 +28,26 @@ sub get_command_output {
 
 my $out;
 
-ok $out = get_command_output( "perl -I$ilib $file start" ), "Started perl daemon";
+ok $out = get_command_output( "$^X -I$ilib $file start" ), "Started perl daemon";
 like $out, qr/\[Started\]/, "Daemon started.";
-ok $out = get_command_output( "perl -I$ilib $file status" ), "Get status of perl daemon.";
+ok $out = get_command_output( "$^X -I$ilib $file status" ), "Get status of perl daemon.";
 like $out, qr/\[Running\]/, "Daemon running.";
 
 sleep 10;
 
-ok $out = get_command_output( "perl -I$ilib $file status" ), "Get status of perl daemon.";
+ok $out = get_command_output( "$^X -I$ilib $file status" ), "Get status of perl daemon.";
 like $out, qr/\[Not Running\]/, "Daemon not running";
 
 # Testing restart.
-ok $out = get_command_output( "perl -I$ilib $file start" ), "Started system daemon";
+ok $out = get_command_output( "$^X -I$ilib $file start" ), "Started system daemon";
 like $out, qr/\[Started\]/, "Daemon started for restarting.";
-ok $out = get_command_output( "perl -I$ilib $file status" ), "Get status of system daemon.";
+ok $out = get_command_output( "$^X -I$ilib $file status" ), "Get status of system daemon.";
 like $out, qr/\[Running\]/, "Daemon running for restarting.";
-ok $out = get_command_output( "perl -I$ilib $file restart" ), "Get status of system daemon.";
+ok $out = get_command_output( "$^X -I$ilib $file restart" ), "Get status of system daemon.";
 like $out, qr/\[Stopped\].*\[Started\]/s, "Daemon restarted.";
-ok $out = get_command_output( "perl -I$ilib $file status" ), "Get status of system daemon.";
+ok $out = get_command_output( "$^X -I$ilib $file status" ), "Get status of system daemon.";
 like $out, qr/\[Running\]/, "Daemon running after restart.";
-ok $out = get_command_output( "perl -I$ilib $file stop" ), "Get status of system daemon.";
+ok $out = get_command_output( "$^X -I$ilib $file stop" ), "Get status of system daemon.";
 like $out, qr/\[Stopped\]/, "Daemon stopped after restart.";
 
 done_testing;

--- a/t/02_sleep_system.t
+++ b/t/02_sleep_system.t
@@ -28,26 +28,26 @@ sub get_command_output {
 
 my $out;
 
-ok $out = get_command_output( "perl -I$ilib $file start" ), "Started system daemon";
+ok $out = get_command_output( "$^X -I$ilib $file start" ), "Started system daemon";
 like $out, qr/\[Started\]/, "Daemon started.";
-ok $out = get_command_output( "perl -I$ilib $file status" ), "Get status of system daemon.";
+ok $out = get_command_output( "$^X -I$ilib $file status" ), "Get status of system daemon.";
 like $out, qr/\[Running\]/, "Daemon running.";
 
 sleep 10;
 
-ok $out = get_command_output( "perl -I$ilib $file status" ), "Get status of system daemon.";
+ok $out = get_command_output( "$^X -I$ilib $file status" ), "Get status of system daemon.";
 like $out, qr/\[Not Running\]/, "Daemon not running.";
 
 # Testing restart.
-ok $out = get_command_output( "perl -I$ilib $file start" ), "Started system daemon";
+ok $out = get_command_output( "$^X -I$ilib $file start" ), "Started system daemon";
 like $out, qr/\[Started\]/, "Daemon started for restarting";
-ok $out = get_command_output( "perl -I$ilib $file status" ), "Get status of system daemon.";
+ok $out = get_command_output( "$^X -I$ilib $file status" ), "Get status of system daemon.";
 like $out, qr/\[Running\]/, "Daemon running for restarting.";
-ok $out = get_command_output( "perl -I$ilib $file restart" ), "Get status of system daemon.";
+ok $out = get_command_output( "$^X -I$ilib $file restart" ), "Get status of system daemon.";
 like $out, qr/\[Stopped\].*\[Started\]/s, "Daemon restarted.";
-ok $out = get_command_output( "perl -I$ilib $file status" ), "Get status of system daemon.";
+ok $out = get_command_output( "$^X -I$ilib $file status" ), "Get status of system daemon.";
 like $out, qr/\[Running\]/, "Daemon running after restart.";
-ok $out = get_command_output( "perl -I$ilib $file stop" ), "Get status of system daemon.";
+ok $out = get_command_output( "$^X -I$ilib $file stop" ), "Get status of system daemon.";
 like $out, qr/\[Stopped\]/, "Daemon stopped after restart.";
 
 done_testing;

--- a/t/03_perl_gets_control.t
+++ b/t/03_perl_gets_control.t
@@ -28,7 +28,7 @@ sub get_command_output {
 
 my $out;
 
-ok $out = get_command_output( "perl -I$ilib $file start" ), "Started perl daemon";
+ok $out = get_command_output( "$^X -I$ilib $file start" ), "Started perl daemon";
 unlike $out, qr/FAILED/, "Code ref gets Daemon::Control instance.";
 
 done_testing;

--- a/t/04_show_warnings.t
+++ b/t/04_show_warnings.t
@@ -30,7 +30,7 @@ sub get_command_output {
 
 my $out;
 
-ok $out = get_command_output( "perl -I$ilib $file show_warnings 2>&1" ), "Get warnings";
+ok $out = get_command_output( "$^X -I$ilib $file show_warnings 2>&1" ), "Get warnings";
 
 is $out, do { local $/; <DATA> }, "Got warnings.";
 


### PR DESCRIPTION
Having this hardcoded makes it a pain in the ass to build this module
under a non-/usr/bin/perl, it's dying when I'm trying to build an RPM
for it because the tests are trying to run under the system perl.
