### PR TITLE
Make it possible to start daemons as root/root by setting user/group to root/root

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+    * Due to checking for true values instead of define it was
+      possible to start a daemon as root by setting uid/gid to 0/0,
+      but not user/group to root/root, which would resolve to 0/0 and
+      be considered an invalid user, which it's not.
     * Fix an encoding error in the POD resulting from Ævar Arnfjörð
       Bjarmason contributing to the project.
     * Tests that invoke Perl now use $^X instead of the $PATH's perl.

--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -94,7 +94,7 @@ sub _set_uid_from_name {
     my ( $self, $name ) = @_;
     my $uid = getpwnam( $name );
     die "Error: Couldn't get uid for non-existent user " . $self->user
-        unless $uid;
+        unless defined $uid;
     $self->trace( "Set UID => $uid" );
     $self->uid( $uid );
 }
@@ -104,7 +104,7 @@ sub _set_gid_from_name {
     my ( $self, $name ) = @_;
     my $gid = getgrnam( $name );
     die "Error: Couldn't get gid for non-existent group " . $self->group
-        unless $gid;
+        unless defined $gid;
     $self->trace( "Set GID => $gid" );
     $self->gid( $gid );
 


### PR DESCRIPTION
Change the check for valid users/groups to check for definiedness
instead of for whether the return value is true. Makes it possible to
run a daemon as root/root.
