### PR TITLE
properly write the pid (not 0) to the pidfile in single fork mode (GH#49)

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@
     * Fix an encoding error in the POD resulting from Ævar Arnfjörð
       Bjarmason contributing to the project.
     * Tests that invoke Perl now use $^X instead of the $PATH's perl.
+    * properly write the pid file in single fork mode (github#XXX)
 
 0.001001  2013-04-29  SymKat <symkat@symkat.com>
     * All 0.001001 changes brought to you by Karen Etheridge; Thanks, ether!

--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -235,7 +235,9 @@ sub _fork {
     } elsif ( not defined $pid ) {
         warn "Cannot fork: $!";
     } else { # In the parent, $pid = child's PID, return it.
-        # Nothing
+        $self->pid( $pid );
+        $self->trace("Set PID => $pid" );
+        $self->write_pid;
     }
     return $self;
 }


### PR DESCRIPTION
The pid in the pid file was "0" in single fork mode -- it looks like it was never being written after it was being cleared out.
