### PR TITLE
Add stdout_pipe/stderr_pipe parameters.

### DIFF
--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -12,11 +12,10 @@ our $VERSION = '0.001004'; # 0.1.4
 $VERSION = eval $VERSION;
 
 my @accessors = qw(
-    pid color_map name program program_args directory quiet
-    uid path gid scan_name stdout_file stderr_file pid_file fork data
-    lsb_start lsb_stop lsb_sdesc lsb_desc redirect_before_fork init_config
-    kill_timeout umask resource_dir help init_code
-    prereq_no_process
+    pid color_map name program program_args directory quiet uid path gid
+    scan_name stdout_file stderr_file stdout_pipe stderr_pipe pid_file fork
+    data lsb_start lsb_stop lsb_sdesc lsb_desc redirect_before_fork init_config
+    kill_timeout umask resource_dir help init_code prereq_no_process
 );
 
 my $cmd_opt = "[start|stop|restart|reload|status|show_warnings|get_init_file|help]";
@@ -77,6 +76,12 @@ sub new {
         if ( exists $args->{$accessor} ) {
             $self->{$accessor} = delete $args->{$accessor};
         }
+
+        if ( $accessor eq 'stdout_pipe' or $accessor eq 'stderr_pipe' ) {
+            die "Bad argument '$accessor': must be either a string or an array-ref of strings!"
+                unless ( !ref($self->{$accessor}) or ref($self->{$accessor}) eq 'ARRAY' );
+        }
+
     }
 
     # Set the user/groups.
@@ -122,12 +127,25 @@ sub redirect_filehandles {
         $self->trace( "STDOUT redirected to $file" );
 
     }
+    elsif ( $self->stdout_pipe ) {
+        my @stdout_pipe = ref($self->stdout_pipe) ? @{ $self->stdout_pipe } : $self->stdout_pipe;
+        open STDOUT, '|-', @stdout_pipe
+            or die "Failed to open STDOUT to pipe @stdout_pipe: $!";
+        $self->trace( "STDOUT redirected to pipe @stdout_pipe" );
+    }
+
     if ( $self->stderr_file ) {
         my $file = $self->stderr_file;
         $file = $file eq '/dev/null' ? File::Spec->devnull : $file;
         open STDERR, ">>", $file
             or die "Failed to open STDERR to $file: $!";
         $self->trace( "STDERR redirected to $file" );
+    }
+    elsif ( $self->stderr_pipe ) {
+        my @stderr_pipe = ref($self->stderr_pipe) ? @{ $self->stderr_pipe } : $self->stderr_pipe;
+        open STDERR, '|-', @stderr_pipe
+            or die "Failed to open STDERR to pipe @stderr_pipe: $!";
+        $self->trace( "STDERR redirected to pipe @stderr_pipe" );
     }
 }
 
@@ -822,6 +840,36 @@ If provided stderr will be redirected to the given file.  This is only supported
 in double fork mode.
 
     $daemon->stderr_file( "/tmp/mydaemon.stderr" );
+
+=head2 stdout_pipe
+
+If provided, stdout will be redirected to a pipe that is opened based on the
+argument/s provided. Accepts either strings or array-refs, which will be passed
+as a list to open(). As with stdout_file, this is only supported in double fork
+mode.
+
+    $daemon->stdout_pipe( "gzip > /var/log/daemon.log.gz" );
+
+    $daemon->stdout_pipe([
+        '/usr/sbin/cronolog',
+        '--symlink=/var/log/daemon.log',
+        '/var/log/daemon-%F.log',
+    ]);
+
+=head2 stderr_pipe
+
+If provided, stderr will be redirected to a pipe that is opened based on the
+argument/s provided. Accepts either strings or array-refs, which will be passed
+as a list to open(). As with stderr_file, this is only supported in double fork
+mode.
+
+    $daemon->stderr_pipe( "gzip > /var/log/daemon_errors.log.gz" );
+
+    $daemon->stderr_pipe([
+        '/usr/sbin/cronolog',
+        '--symlink=/var/log/daemon_errors.log',
+        '/var/log/daemon_errors-%F.log',
+    ]);
 
 =head2 pid_file
 

--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -829,23 +829,23 @@ passed to redirect the filehandles.
 
 =head2 stdout_file
 
-If provided stdout will be redirected to the given file.  This is only supported
-in double fork mode.
+If provided, STDOUT will be redirected to the given file. This is only
+supported in double fork mode.
 
     $daemon->stdout_file( "/tmp/mydaemon.stdout" );
 
 =head2 stderr_file
 
-If provided stderr will be redirected to the given file.  This is only supported
-in double fork mode.
+If provided, STDERR will be redirected to the given file. This is only
+supported in double fork mode.
 
     $daemon->stderr_file( "/tmp/mydaemon.stderr" );
 
 =head2 stdout_pipe
 
-If provided, stdout will be redirected to a pipe that is opened based on the
-argument/s provided. Accepts either strings or array-refs, which will be passed
-as a list to open(). As with stdout_file, this is only supported in double fork
+If provided, STDOUT will be redirected to a pipe based on the given parameter.
+Accepts either a string or an array-ref, which will be passed in list context
+to C<open>. As with C<->stdout_file>, this is only supported in double fork
 mode.
 
     $daemon->stdout_pipe( "gzip > /var/log/daemon.log.gz" );
@@ -858,9 +858,9 @@ mode.
 
 =head2 stderr_pipe
 
-If provided, stderr will be redirected to a pipe that is opened based on the
-argument/s provided. Accepts either strings or array-refs, which will be passed
-as a list to open(). As with stderr_file, this is only supported in double fork
+If provided, STDERR will be redirected to a pipe based on the given parameter.
+Accepts either a string or an array-ref, which will be passed in list context
+to C<open>. As with C<->stderr_file>, this is only supported in double fork
 mode.
 
     $daemon->stderr_pipe( "gzip > /var/log/daemon_errors.log.gz" );

--- a/t/05_log_piping.t
+++ b/t/05_log_piping.t
@@ -1,0 +1,75 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+
+use Test::More;
+use File::Temp;
+
+my ( $file, $ilib );
+
+# Let's make it so people can test in t/ or in the dist directory.
+if ( -f 't/bin/05_log_piping.t' ) { # Dist Directory.
+    $file = "t/bin/05_log_piping.t";
+    $ilib = "lib";
+} elsif ( -f 'bin/05_log_piping.t' ) {
+    $file = "bin/05_log_piping.t";
+    $ilib = "../lib";
+} else {
+    die "Tests should be run in the dist directory or t/";
+}
+
+my $pid_temp_file    = File::Temp->new(UNLINK => 0);
+my $stdout_temp_file = File::Temp->new(UNLINK => 0);
+my $stderr_temp_file = File::Temp->new(UNLINK => 0);
+
+my $pid_temp_filename    = $pid_temp_file->filename;
+my $stdout_temp_filename = $stdout_temp_file->filename;
+my $stderr_temp_filename = $stderr_temp_file->filename;
+
+# diag "\$stdout_temp_filename: $stdout_temp_filename";
+# diag "\$stderr_temp_filename: $stderr_temp_filename";
+
+ok(system("$^X -I$ilib $file start $pid_temp_filename $stdout_temp_filename $stderr_temp_filename") == 0, "Started perl daemon");
+
+# sleep 2 seconds, checking each 0.1 second for output from the daemon
+# hopefully that's long enough to start up and finish. the alternative
+# is that we actually use pid files, etc
+
+my $pid;
+
+foreach (1 .. 20) {
+    # -f $stdout_temp_filename && -s _ and -f $stderr_temp_filename && -s _ and last;
+
+    $pid_temp_file->seek(0, 0);
+
+    chomp( $pid = <$pid_temp_file> );
+
+    # diag "checking spawned pid $pid";
+
+    if ($pid) {
+        kill 0, $pid or last;
+    }
+
+    select undef, undef, undef, 0.1;
+}
+
+die "child process [$pid] still running, is it frozen?" if $pid and kill(0, $pid);
+
+$stdout_temp_file->seek(0, 0);
+$stderr_temp_file->seek(0, 0);
+
+chomp(my $captured_stdout = <$stdout_temp_file>);
+chomp(my $captured_stderr = <$stderr_temp_file>);
+
+unlink $pid_temp_file->filename;
+unlink $stdout_temp_file->filename;
+unlink $stderr_temp_file->filename;
+
+undef $pid_temp_file;
+undef $stdout_temp_file;
+undef $stderr_temp_file;
+
+is( $captured_stdout, 'I am in here', 'test stdout_pipe' );
+is( $captured_stderr, 'Te Occidere Possunt Sed Te Edere Non Possunt Nefas Est', 'test stdout_pipe' );
+
+done_testing;

--- a/t/05_log_piping.t
+++ b/t/05_log_piping.t
@@ -70,6 +70,6 @@ undef $stdout_temp_file;
 undef $stderr_temp_file;
 
 is( $captured_stdout, 'I am in here', 'test stdout_pipe' );
-is( $captured_stderr, 'Te Occidere Possunt Sed Te Edere Non Possunt Nefas Est', 'test stdout_pipe' );
+is( $captured_stderr, 'Te Occidere Possunt Sed Te Edere Non Possunt Nefas Est', 'test stderr_pipe' );
 
 done_testing;

--- a/t/05_log_piping.t
+++ b/t/05_log_piping.t
@@ -31,15 +31,12 @@ my $stderr_temp_filename = $stderr_temp_file->filename;
 
 ok(system("$^X -I$ilib $file start $pid_temp_filename $stdout_temp_filename $stderr_temp_filename") == 0, "Started perl daemon");
 
-# sleep 2 seconds, checking each 0.1 second for output from the daemon
-# hopefully that's long enough to start up and finish. the alternative
-# is that we actually use pid files, etc
+# sleep 2 seconds, during which perform a check each 0.1 second to determine
+# whether the test daemon is still running.
 
 my $pid;
 
 foreach (1 .. 20) {
-    # -f $stdout_temp_filename && -s _ and -f $stderr_temp_filename && -s _ and last;
-
     $pid_temp_file->seek(0, 0);
 
     chomp( $pid = <$pid_temp_file> );

--- a/t/bin/05_log_piping.t
+++ b/t/bin/05_log_piping.t
@@ -1,0 +1,34 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+use Daemon::Control;
+
+my ($pid_file, $stdout_temp_file, $stderr_temp_file);
+
+if ( @ARGV == 4 ) {
+  ($pid_file, $stdout_temp_file, $stderr_temp_file) = splice(@ARGV, -3);
+}
+
+die "bad stdout_temp_file [$stdout_temp_file]" unless $stdout_temp_file and -f $stdout_temp_file;
+die "bad stderr_temp_file [$stderr_temp_file]" unless $stderr_temp_file and -f $stderr_temp_file;
+
+Daemon::Control->new({
+    name        => "My Daemon",
+    lsb_start   => '$syslog $remote_fs',
+    lsb_stop    => '$syslog',
+    lsb_sdesc   => 'My Daemon Short',
+    lsb_desc    => 'My Daemon controls the My Daemon daemon.',
+    path        => '/usr/sbin/mydaemon/init.pl',
+
+    program     => sub {
+        print STDOUT "I am in here\n";
+        print STDERR "Te Occidere Possunt Sed Te Edere Non Possunt Nefas Est\n";
+    },
+
+    pid_file    => $pid_file,
+    stdout_pipe => "cat > $stdout_temp_file",
+    stderr_pipe => "cat > $stderr_temp_file",
+
+    fork        => 2,
+
+})->run;

--- a/t/bin/05_log_piping.t
+++ b/t/bin/05_log_piping.t
@@ -9,6 +9,7 @@ if ( @ARGV == 4 ) {
   ($pid_file, $stdout_temp_file, $stderr_temp_file) = splice(@ARGV, -3);
 }
 
+die "bad pid_file [$pid_file]" unless $pid_file and -f $pid_file;
 die "bad stdout_temp_file [$stdout_temp_file]" unless $stdout_temp_file and -f $stdout_temp_file;
 die "bad stderr_temp_file [$stderr_temp_file]" unless $stderr_temp_file and -f $stderr_temp_file;
 
@@ -30,5 +31,4 @@ Daemon::Control->new({
     stderr_pipe => "cat > $stderr_temp_file",
 
     fork        => 2,
-
 })->run;


### PR DESCRIPTION
Instead of logging directly to a file, instead we redirect STDOUT/STDERR to a
pipe, which allows for redirection of the daemon's log output through an
arbitrary pipeline (perhaps e.g. immediately compressing the daemon's output to
disk using gzip) or feeding the output into a pipe-based log collector such as
cronolog.
