### PR TITLE
Exit status fix

### DIFF
--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -625,7 +625,7 @@ sub run_command {
 
 # Application Code.
 sub run {
-    shift->run_command( @ARGV );
+    exit shift->run_command( @ARGV );
 }
 
 sub trace {

--- a/t/02_sleep_system.t
+++ b/t/02_sleep_system.t
@@ -32,11 +32,11 @@ ok $out = get_command_output( "$^X -I$ilib $file start" ), "Started system daemo
 like $out, qr/\[Started\]/, "Daemon started.";
 ok $out = get_command_output( "$^X -I$ilib $file status" ), "Get status of system daemon.";
 like $out, qr/\[Running\]/, "Daemon running.";
-
+ok $? >> 8 == 0, "Exit Status = 0";
 sleep 10;
-
 ok $out = get_command_output( "$^X -I$ilib $file status" ), "Get status of system daemon.";
 like $out, qr/\[Not Running\]/, "Daemon not running.";
+ok $? >> 8 == 3, "Exit Status = 3";
 
 # Testing restart.
 ok $out = get_command_output( "$^X -I$ilib $file start" ), "Started system daemon";


### PR DESCRIPTION
The status was returned, but not used in exit.
Here's a fix, including tests.
