### PR TITLE
Now also sets uid and gid when not forking.

### DIFF
--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -421,7 +421,14 @@ sub do_start {
     $self->fork( 2 ) unless defined $self->fork;
     $self->_double_fork if $self->fork == 2;
     $self->_fork if $self->fork == 1;
-    $self->_foreground if $self->fork == 0;
+
+    if ($self->fork == 0) {
+        $self->pretty_print( "Starting" );
+        setuid($self->uid);
+        setgid($self->gid);
+        $self->_foreground;
+    }
+
     $self->pretty_print( "Started" );
     return 0;
 }


### PR DESCRIPTION
Hi symkat.

It appears that not forking will not change the uid and gid of the process, as desired. Hopefully, we are running with elevated permissions so we can change the privileges, and so this should help.

Regards, ath88