### PR TITLE
pid check works now for all users

### DIFF
--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -358,7 +358,7 @@ sub pid_running {
     $pid ||= $self->read_pid;
 
     return 0 unless $self->pid >= 1;
-    return 0 unless kill 0, $self->pid;
+    return 0 unless (kill(0, $self->pid) || $!{EPERM});
 
     if ( $self->scan_name ) {
         open my $lf, "-|", "ps", "-p", $self->pid, "-o", "command="
@@ -367,9 +367,9 @@ sub pid_running {
             return 1 if $line =~ $self->scan_name;
         }
         return 0;
+    } else {
+	return 1;
     }
-    # Scan name wasn't used, testing normal PID.
-    return kill 0, $self->pid;
 }
 
 sub process_running {


### PR DESCRIPTION
Running "status" used to show the wrong result if the daemon was
started for a different user. According to perlipc.pod it's best to
check for $!{EPERM} after a failed kill 0 => ...

The pid_running() function was also simplified to call kill 0 => ...
only once, the 2nd call was actually redundant.
