### PR TITLE
Print 'Started' before launching program when running in foreground

### DIFF
--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -266,7 +266,11 @@ sub _double_fork {
     return $self;
 }
 
-sub _foreground { shift->_launch_program } 
+sub _foreground {
+    my $self = shift;
+    $self->pretty_print( "Started" );
+    $self->_launch_program
+}
 
 sub _fork {
     my ( $self ) = @_;


### PR DESCRIPTION
We use Daemon::Control to launch hypnotoad (Mojolicious), but run with fork => 0 as hypnotoad does the
forking.

The 'Started' print statement in do_start() is never reached when not forking - so the init script does not give any
response.