### PR TITLE
Change init file: give all arguments to script

### DIFF
--- a/lib/Daemon/Control.pm
+++ b/lib/Daemon/Control.pm
@@ -729,7 +729,7 @@ __DATA__
 
 if [ -x [% SCRIPT %] ];
 then
-    [% SCRIPT %] $1
+    [% SCRIPT %] $@
 else
     echo "Required program [% SCRIPT %] not found!"
     exit 1;


### PR DESCRIPTION
This pull request changes the init file to give all arguments given to it to the actual perl script.

Why:
We use Daemon::Control in a custom script with lots of arguments. We then store most of the arguments in the init code block in form of environment variables. We then use the init scripts as shortcuts for specific configurations, i.e. "customer_1_start", "customer_2_start" or "dev_littlefox_start". Sometimes we want to change some arguments from the defaults saved that way and this patch allows us to do this.