### PR TITLE
add '.' to @INC before using it

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,5 @@
-use inc::Module::Install;
 BEGIN { push @INC, '.' unless $INC[-1] eq '.' }
+use inc::Module::Install;
 
 # Define metadata
 name           'Daemon-Control';


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Daemon-Control.
We thought you might be interested in it too.

    Description: add '.' to @INC before using it
     as in: before, not after â¦
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2019-02-20
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libdaemon-control-perl/raw/master/debian/patches/dot-in-inc.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
